### PR TITLE
added: parent's transform:scale() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,30 @@ With this parameter, you can set the bounding area for the component, and also i
 <vue-drag-resize :parentH="2000">
 ```
 
+#### parentScaleX
+Type: `Number`<br>
+Required: `false`<br>
+Default: `1`
+
+Define the initial horizontal scale or the parent element. Same value in parent's transform: scale() css definition.
+The drag/resize and the sticks' sizes will computed with this value.
+
+```html
+<vue-drag-resize :parentScaleX="0.5">
+```
+
+#### parentScaleY
+Type: `Number`<br>
+Required: `false`<br>
+Default: `1`
+
+Define the initial vertical scale or the parent element. Same value in parent's transform: scale() css definition.
+The drag/resize and the sticks' sizes will computed with this value.
+
+```html
+<vue-drag-resize :parentScaleY="0.5">
+```
+
 #### isDraggable
 Type: `Boolean`<br>
 Required: `false`<br>

--- a/src/components/vue-drag-resize.css
+++ b/src/components/vue-drag-resize.css
@@ -1,7 +1,3 @@
-:root{
-    --stick-size: 8px;
-}
-
 .vdr {
     position: absolute;
     box-sizing: border-box;
@@ -18,8 +14,6 @@
 .vdr-stick {
     box-sizing: border-box;
     position: absolute;
-    width: var(--stick-size);
-    height: var(--stick-size);
     font-size: 1px;
     background: #ffffff;
     border: 1px solid #6c6c6c;
@@ -28,49 +22,19 @@
 .inactive .vdr-stick {
     display: none;
 }
-.vdr-stick-tl {
-    top: calc(var(--stick-size)/-2);
-    left: calc(var(--stick-size)/-2);
+.vdr-stick-tl, .vdr-stick-br {
     cursor: nwse-resize;
 }
-.vdr-stick-tm {
-    top: calc(var(--stick-size)/-2);
+.vdr-stick-tm, .vdr-stick-bm {
     left: 50%;
-    margin-left: calc(var(--stick-size)/-2);
     cursor: ns-resize;
 }
-.vdr-stick-tr {
-    top: calc(var(--stick-size)/-2);
-    right: calc(var(--stick-size)/-2);
+.vdr-stick-tr, .vdr-stick-bl {
     cursor: nesw-resize;
 }
-.vdr-stick-ml {
+.vdr-stick-ml, .vdr-stick-mr {
     top: 50%;
-    margin-top: calc(var(--stick-size)/-2);
-    left: calc(var(--stick-size)/-2);
     cursor: ew-resize;
-}
-.vdr-stick-mr {
-    top: 50%;
-    margin-top: calc(var(--stick-size)/-2);
-    right: calc(var(--stick-size)/-2);
-    cursor: ew-resize;
-}
-.vdr-stick-bl {
-    bottom: calc(var(--stick-size)/-2);
-    left: calc(var(--stick-size)/-2);
-    cursor: nesw-resize;
-}
-.vdr-stick-bm {
-    bottom: calc(var(--stick-size)/-2);
-    left: 50%;
-    margin-left: calc(var(--stick-size)/-2);
-    cursor: ns-resize;
-}
-.vdr-stick-br {
-    bottom: calc(var(--stick-size)/-2);
-    right: calc(var(--stick-size)/-2);
-    cursor: nwse-resize;
 }
 .vdr-stick.not-resizable{
     display: none;

--- a/src/components/vue-drag-resize.html
+++ b/src/components/vue-drag-resize.html
@@ -8,7 +8,8 @@
             class="vdr-stick"
             :class="['vdr-stick-' + stick, isResizable ? '' : 'not-resizable']"
             @mousedown.stop.prevent="stickDown(stick, $event)"
-            @touchstart.stop.prevent="stickDown(stick, $event)">
+            @touchstart.stop.prevent="stickDown(stick, $event)"
+            :style="vdrStick(stick)">
     </div>
 
 </div>

--- a/src/components/vue-drag-resize.html
+++ b/src/components/vue-drag-resize.html
@@ -1,5 +1,5 @@
 <div class="vdr" :style="style"
-     :class="active ? 'active' : 'inactive'"
+     :class="active || isActive ? 'active' : 'inactive'"
      @mousedown.stop.prevent="bodyDown($event)"
      @touchstart.stop.prevent="bodyDown($event)">
     <slot></slot>

--- a/src/components/vue-drag-resize.js
+++ b/src/components/vue-drag-resize.js
@@ -1,6 +1,26 @@
+const stickSize = 8;
+const styleMapping = {
+  y: {
+    t: 'top',
+    m: 'marginTop',
+    b: 'bottom',
+  },
+  x: {
+    l: 'left',
+    m: 'marginLeft',
+    r: 'right',
+  }
+};
+
 export default {
     name: 'vue-drag-resize',
     props: {
+        parentScaleX: {
+          type: Number, default: 1,
+        },
+        parentScaleY: {
+          type: Number, default: 1,
+        },
         isActive: {
             type: Boolean, default: false
         },
@@ -280,8 +300,8 @@ export default {
             const stickStartPos = this.stickStartPos;
 
             let delta = {
-                x: this.axis !== 'y' && this.axis !== 'none' ? stickStartPos.mouseX - ev.x : 0,
-                y: this.axis !== 'x' && this.axis !== 'none' ? stickStartPos.mouseY - ev.y : 0
+                x: (this.axis !== 'y' && this.axis !== 'none' ? stickStartPos.mouseX - ev.x : 0) / this.parentScaleX,
+                y: (this.axis !== 'x' && this.axis !== 'none' ? stickStartPos.mouseY - ev.y : 0) / this.parentScaleY
             };
 
             this.rawTop = stickStartPos.top - delta.y;
@@ -418,8 +438,8 @@ export default {
             const stickStartPos = this.stickStartPos;
 
             const delta = {
-                x: stickStartPos.mouseX - ev.x,
-                y: stickStartPos.mouseY - ev.y
+                x: (stickStartPos.mouseX - ev.x) / this.parentScaleX,
+                y: (stickStartPos.mouseY - ev.y) / this.parentScaleY
             };
 
             switch (this.currentStick[0]) {
@@ -516,6 +536,18 @@ export default {
                 width: this.width + 'px',
                 height: this.height + 'px',
                 zIndex: this.zIndex
+            }
+        },
+
+        vdrStick() {
+            return (stick) => {
+                const stickStyle = {
+                    width: `${stickSize / this.parentScaleX}px`,
+                    height: `${stickSize / this.parentScaleY}px`,
+                };
+                stickStyle[styleMapping.y[stick[0]]] = `${stickSize / this.parentScaleX / -2}px`;
+                stickStyle[styleMapping.x[stick[1]]] = `${stickSize / this.parentScaleX / -2}px`;
+                return stickStyle;
             }
         },
 


### PR DESCRIPTION
There's a transform:scale() in my project's parent style, move/resize and the stick sizes are not functioning properly.
So, I added parentScaleX and parentScaleY properties to support part of transform:scale() functions.

My case, parent's style:
![image](https://user-images.githubusercontent.com/1819895/40899071-997b9aac-67f7-11e8-8e00-c24c3106eb93.png)

displaying:
![image](https://user-images.githubusercontent.com/1819895/40899093-b3f169b6-67f7-11e8-9012-079e8b6b2fe1.png)
