### PR TITLE
stop propagation and prevent event only if currently active and resizing/dragging

### DIFF
--- a/src/components/vue-drag-resize.html
+++ b/src/components/vue-drag-resize.html
@@ -1,7 +1,7 @@
 <div class="vdr" :style="style"
      :class="active || isActive ? 'active' : 'inactive'"
-     @mousedown.stop.prevent="bodyDown($event)"
-     @touchstart.stop.prevent="bodyDown($event)">
+     @mousedown="bodyDown($event)"
+     @touchstart="bodyDown($event)">
     <slot></slot>
     <div
             v-for="stick in sticks"

--- a/src/components/vue-drag-resize.js
+++ b/src/components/vue-drag-resize.js
@@ -268,6 +268,9 @@ export default {
             if (this.dragCancel && target.getAttribute('data-drag-cancel') === this._uid.toString()) {
                 return
             }
+          
+            ev.stopPropagation();
+            ev.preventDefault();
 
             this.bodyDrag = true;
 


### PR DESCRIPTION
This PR enables the use of text selection (#14), input fields and probably much more related to the prevented event propagation.

It moves the preventDefault and stopPropagation to after the checks in the bodyDown method, so stuff works normally until the element is resizing or dragged.