### PR TITLE
Fix dragstop and resizestop not fired

### DIFF
--- a/src/components/vue-drag-resize.html
+++ b/src/components/vue-drag-resize.html
@@ -1,7 +1,8 @@
 <div class="vdr" :style="style"
      :class="active || isActive ? 'active' : 'inactive'"
      @mousedown="bodyDown($event)"
-     @touchstart="bodyDown($event)">
+     @touchstart="bodyDown($event)"
+     @touchend="up($event)">
     <slot></slot>
     <div
             v-for="stick in sticks"


### PR DESCRIPTION
In chrome touch mode, `dragstop` and `resizestop` were not fired immediately after releasing an element. This is because the global documentElement touchend event was never fired when you started the touch on an element.

By adding a touchend event to the element, we make sure that the up method is called. This effectively emmits the `dragstop` and `resizestop` events immediately.

This fixes #37