### PR TITLE
Make stickSize a component prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### Features
 
-* A lightweight, no-dependency 
+* A lightweight, no-dependency
 * All props are reactive
 * Support touch events
 * Use draggable, resizable or both
@@ -98,7 +98,7 @@ Type: `Boolean`<br>
 Required: `false`<br>
 Default: `false`
 
-Determines whether the component should be active. 
+Determines whether the component should be active.
 
 ```html
 <vue-drag-resize :isActive="true">
@@ -282,6 +282,17 @@ Define the zIndex of the component.
 
 ```html
 <vue-drag-resize :z="999">
+```
+
+#### stickSize
+Type: `Number`<br>
+Required: `false`<br>
+Default `8`
+
+Define the sticks' size.
+
+```html
+<vue-drag-resize :stickSize="12">
 ```
 
 #### sticks

--- a/src/components/vue-drag-resize.js
+++ b/src/components/vue-drag-resize.js
@@ -1,4 +1,3 @@
-const stickSize = 8;
 const styleMapping = {
   y: {
     t: 'top',
@@ -15,6 +14,9 @@ const styleMapping = {
 export default {
     name: 'vue-drag-resize',
     props: {
+        stickSize: {
+          type: Number, default: 8,
+        },
         parentScaleX: {
           type: Number, default: 1,
         },
@@ -268,7 +270,7 @@ export default {
             if (this.dragCancel && target.getAttribute('data-drag-cancel') === this._uid.toString()) {
                 return
             }
-          
+
             ev.stopPropagation();
             ev.preventDefault();
 
@@ -549,11 +551,11 @@ export default {
         vdrStick() {
             return (stick) => {
                 const stickStyle = {
-                    width: `${stickSize / this.parentScaleX}px`,
-                    height: `${stickSize / this.parentScaleY}px`,
+                    width: `${this.stickSize / this.parentScaleX}px`,
+                    height: `${this.stickSize / this.parentScaleY}px`,
                 };
-                stickStyle[styleMapping.y[stick[0]]] = `${stickSize / this.parentScaleX / -2}px`;
-                stickStyle[styleMapping.x[stick[1]]] = `${stickSize / this.parentScaleX / -2}px`;
+                stickStyle[styleMapping.y[stick[0]]] = `${this.stickSize / this.parentScaleX / -2}px`;
+                stickStyle[styleMapping.x[stick[1]]] = `${this.stickSize / this.parentScaleX / -2}px`;
                 return stickStyle;
             }
         },


### PR DESCRIPTION
This change allows the sticks to be made larger, especially useful for touchscreens where the default size can be a little cumbersome to hit.

- turn `stickSize` constant into a component prop, having the default value of 8
- add documentation