### PR TITLE
fix: `getAttribute` get called on undefined target user event

### DIFF
--- a/src/components/vue-drag-resize.js
+++ b/src/components/vue-drag-resize.js
@@ -299,11 +299,11 @@ export default {
                 return;
             }
 
-            if (this.dragHandle && target.getAttribute('data-drag-handle') !== this._uid.toString()) {
+            if (this.dragHandle && target?.getAttribute('data-drag-handle') !== this._uid.toString()) {
                 return;
             }
 
-            if (this.dragCancel && target.getAttribute('data-drag-cancel') === this._uid.toString()) {
+            if (this.dragCancel && target?.getAttribute('data-drag-cancel') === this._uid.toString()) {
                 return;
             }
 


### PR DESCRIPTION
This PR is to fix the case where target might be `undefined` and calling `getAttribute` function will throw error into user browser console